### PR TITLE
Update build infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,39 @@
-build:
-	cd fist && make
-	mkdir -p bin
-	mv fist/fist bin/fist
+MAKEFLAGS += -r
+
+BINDIR := bin
+BIN := $(BINDIR)/fist
+BIN_SOURCES := \
+	fist/dstring.c \
+	fist/fist.c \
+	fist/hashmap.c \
+	fist/indexer.c \
+	fist/serializer.c \
+	fist/server.c \
+	fist/tests.c \
+	fist/utils.c
+BIN_OBJECTS := $(BIN_SOURCES:=.o)
+BIN_DEPS := $(BIN_SOURCES:=.d)
+
+CC ?= gcc
+CFLAGS ?= -Wall -O2 -g
+CFLAGS += -std=c99
+LDFLAGS ?=
+LDLIBS :=
+MKDIR ?= mkdir -p
+RM ?= rm -f
+
+.PHONY: all clean
+
+all: $(BIN)
+
+$(BIN): $(BIN_OBJECTS)
+	$(MKDIR) $(BINDIR)
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+%.c.o: %.c
+	$(CC) $(CFLAGS) -MMD -MP -c $< -o $@
+
+clean:
+	$(RM) $(BIN) $(BIN_OBJECTS) $(BIN_DEPS)
+
+-include $(BIN_DEPS)

--- a/fist/Makefile
+++ b/fist/Makefile
@@ -1,3 +1,0 @@
-
-all: $(find ./ | grep ".c")
-	gcc -Wall *.c -o ./fist 


### PR DESCRIPTION
The old Makefile worked okay, but this one allows for parallel build jobs (make -jN) and includes header files in the dependency graph.