### PR TITLE
Added ability to use the stack for small strings

### DIFF
--- a/fist/dstring.c
+++ b/fist/dstring.c
@@ -4,55 +4,74 @@
 #include <stdlib.h>
 
 int dequals(dstring s1, dstring s2) {
-    return !strcmp(s1.text, s2.text); 
+    return !strcmp(dtext(s1), dtext(s2));
 }
 
 dstring dappendc(dstring input, char character) {
     int new_size = input.length + 2;
-    char *string = realloc(input.text, sizeof(char) * new_size);
+    char *string;
+    if (input.alloc_len == 0) {
+        if (new_size <= DSTRING_SMALL) {
+            string = input.static_text;
+        } else {
+            string = malloc(sizeof(char *) * new_size);
+            memcpy(string, input.static_text, input.length);
+            input.alloc_len = new_size;
+            input.text = string;
+        }
+    } else {
+        string = realloc(dtext(input), sizeof(char) * new_size);
+        input.alloc_len = new_size;
+        input.text = string;
+    }
     string[input.length] = character;
     string[input.length + 1] = 0;
     input.length++;
-    input.text = string;
     return input;
 }
 
 dstring dappend(dstring input, char *characters) {
     int increase_by = strlen(characters) + 1;
-    int new_size = strlen(input.text) + increase_by;
-    char *new_dstring = realloc(input.text, sizeof(char) * new_size);
-    strncat(new_dstring, characters, increase_by - 1);
-    new_dstring[new_size - 1] = 0;
+    int new_size = strlen(dtext(input)) + increase_by;
+    char *new_dstring = NULL;
+
+    if (input.alloc_len == 0) {
+        if (new_size <= DSTRING_SMALL) {
+            new_dstring = input.static_text;
+        } else {
+            new_dstring = malloc(sizeof(char) * new_size);
+            strcpy(new_dstring, input.static_text);
+            input.alloc_len = new_size;
+            input.text = new_dstring;
+        }
+    } else {
+        new_dstring = realloc(input.text, sizeof(char) * new_size);
+        input.alloc_len = new_size;
+        input.text = new_dstring;
+    }
+    memcpy(&new_dstring[input.length], characters, increase_by);
+
     input.length += increase_by - 1;
-    input.text = new_dstring;
     return input;
 }
 
 dstring dappendd(dstring input, dstring word) {
-    return dappend(input, word.text);
+    return dappend(input, dtext(word));
 }
 
 dstring dempty() {
-    char *empty = malloc(sizeof(char));
-    empty[0] = 0;
-    dstring empty_dstring = {0, empty};
+    dstring empty_dstring = {0, NULL, 0, {'\0'}};
     return empty_dstring;
 }
 
 dstring dcreate(char *initial) {
-    int string_length = strlen(initial);
-    int buff_size = strlen(initial) + 1;
-    char *buffer = malloc(sizeof(char) * buff_size);
-    memset(buffer, 0, buff_size);
-    memcpy(buffer, initial, string_length);
-    dstring new_dstring = {string_length, buffer};
-    return new_dstring;
+    return dappend(dempty(), initial);
 }
 
 dstring dreverse(dstring input) {
     dstring reversed = dempty();
     for(int i = input.length - 1; i >= 0; i--) {
-        reversed = dappendc(reversed, input.text[i]);
+        reversed = dappendc(reversed, dtext(input)[i]);
     }
     return reversed;
 }
@@ -60,7 +79,7 @@ dstring dreverse(dstring input) {
 int dcount(dstring input, char character) {
     int occurances = 0;
     for(int i = 0; i < input.length; i++) {
-        if(input.text[i] == character)
+        if(dtext(input)[i] == character)
             occurances++;
     }
 
@@ -70,7 +89,7 @@ int dcount(dstring input, char character) {
 int dindexof(dstring input, char character) {
     int index = -1;
     for(int i = 0; i < input.length; i++) {
-        if(input.text[i] == character) {
+        if(dtext(input)[i] == character) {
             index = i;
             break;
         }
@@ -80,13 +99,12 @@ int dindexof(dstring input, char character) {
 }
 
 dstringa dcreatea() {
-    dstring *empty = malloc(sizeof(dstring));
-    dstringa strings = {0, empty}; 
+    dstringa strings = {0, NULL};
     return strings;
 }
 
 dstringa dpush(dstringa array, dstring input) {
-    dstring new = dcreate(input.text); // Created new object
+    dstring new = dcreate(dtext(input)); // Created new object
     int new_length = array.length + 1;
     dstring *new_array = realloc(array.values, sizeof(dstring) * new_length);
     new_array[array.length] = new;
@@ -108,7 +126,7 @@ int dindexofa(dstringa array, dstring input) {
 dstring djoin(dstringa array, char with) {
     dstring output = dempty();
     for(int i = 0; i < array.length; i++) {
-        output = dappend(output, array.values[i].text);
+        output = dappend(output, dtext(array.values[i]));
         if( i != array.length - 1)
             output = dappendc(output, with);
     }
@@ -144,11 +162,11 @@ dstringa drange(dstringa array, int start, int end) {
 }
 
 dstringa dsplit(dstring input, char at) {
-    dstring new = dcreate(input.text);
+    dstring new = dcreate(dtext(input));
     dstringa array = dcreatea();
     dstring string = dempty();
     for(int i = 0; i < new.length; i++) {
-        char on = new.text[i];
+        char on = dtext(new)[i];
         if(on == at && string.length > 0) {
             array = dpush(array, string);
             string = dempty();
@@ -168,7 +186,7 @@ int dfreea(dstringa array) {
     for(int i = 0; i < array.length; i++) {
         dfree(array.values[i]);
     }
-    
+
     free(array.values);
     return array.length;
 }
@@ -221,7 +239,7 @@ dstringa dset(dstringa array, unsigned int index, dstring with) {
 dstring dsubstr(dstring input, unsigned int start, unsigned int end) {
     if(start > input.length - 1 || end > input.length - 1) {
         return input;
-    } 
+    }
 
     if(end < start) {
         int tmp = end;
@@ -231,7 +249,7 @@ dstring dsubstr(dstring input, unsigned int start, unsigned int end) {
 
     dstring output = dempty();
     for(int i = start; i <= end; i++) {
-        output = dappendc(output, input.text[i]);
+        output = dappendc(output, dtext(input)[i]);
     }
     dfree(input);
     return output;
@@ -239,17 +257,17 @@ dstring dsubstr(dstring input, unsigned int start, unsigned int end) {
 
 dstring dtrim(dstring input) {
     int end_index = input.length - 1;
-    char end_char = input.text[end_index];
+    char end_char = dtext(input)[end_index];
     while((end_char == ' ' || end_char == '\n' || end_char == '\r' || end_char == '\t') && end_index > 0) {
         end_index--;
-        end_char = input.text[end_index];
+        end_char = dtext(input)[end_index];
     }
 
     int start_index = 0;
-    char start_char = input.text[0];
+    char start_char = dtext(input)[0];
     while(start_index < end_index && (start_char == '\n' || start_char == ' ' || start_char == '\t' || start_char == '\r')) {
         start_index++;
-        start_char = input.text[start_index];
+        start_char = dtext(input)[start_index];
     }
 
     dstring output = dsubstr(input, start_index, end_index);
@@ -260,7 +278,7 @@ dstring dtrim(dstring input) {
 dstring dreplace(dstring input, char character, char with) {
     dstring new_string = dempty();
     for(int i = 0; i < input.length; i++) {
-        char on = input.text[i];
+        char on = dtext(input)[i];
         if(on == character) {
             new_string = dappendc(new_string, with);
         } else {
@@ -273,6 +291,7 @@ dstring dreplace(dstring input, char character, char with) {
 }
 
 int dfree(dstring string) {
-    free(string.text);
+    if (string.alloc_len != 0)
+        free(string.text);
     return string.length;
 }

--- a/fist/dstring.h
+++ b/fist/dstring.h
@@ -1,15 +1,30 @@
 #ifndef H_DSTRING
 #define H_DSTRING
 
+// Size of a small word that we want to keep on the stack to avoid multiple alloc/realloc calls.
+// Increasing this will reduce malloc overhead, improve cache hits, but increase memory wasatage.
+#define DSTRING_SMALL 32
+
 typedef struct dstring {
     int length;
     char *text;
+	int alloc_len;
+    char static_text[DSTRING_SMALL];
 } dstring;
 
 typedef struct dstringa {
     int length;
     dstring *values;
 } dstringa;
+
+#define dtext(input) ({ \
+		char *retval; \
+		if (input.alloc_len == 0) \
+			retval = input.static_text; \
+		else \
+			retval = input.text; \
+		retval; \
+	})
 
 int dequals(dstring s1, dstring s2);
 dstring dappendc(dstring input, char character); // Apppend single char to string
@@ -25,7 +40,7 @@ int dcount(dstring input, char character); // Count occurances of a character in
 int dfree(dstring string); // Frees a dstring's memory
 dstring dappendd(dstring input, dstring word); // Append two dstrings together
 
-// List of dstrings 
+// List of dstrings
 
 dstringa dsplit(dstring input, char at); // Splits string at character
 dstringa dcreatea(); // Create empty array of dstrings

--- a/fist/hashmap.c
+++ b/fist/hashmap.c
@@ -15,24 +15,39 @@ int hash(char *val) {
 }
 
 hashmap *hcreate() {
-    hashmap *hm = malloc(sizeof(hashmap) * HMAP_SIZE);
+    hashmap *hm = calloc(sizeof(hashmap), HMAP_SIZE);
     return hm;
 }
 
+void hfree(hashmap *hm)
+{
+    // TODO: Free every key
+    for (int i = 0 ; i < HMAP_SIZE; i++) {
+        hashmap *map_array = &hm[i];
+        for (int j = 0; j < map_array->length; j++) {
+            dfree(map_array->maps[j].key);
+            dfreea(map_array->maps[j].values);
+        }
+        free(map_array->maps);
+    }
+
+    free(hm);
+}
+
 hashmap *hset(hashmap *hm, dstring key, dstring value) {
-    int hash_val = hash(key.text);
-    hashmap map_array = hm[hash_val];
-    int length = map_array.length;
+    int hash_val = hash(dtext(key));
+    hashmap *map_array = &hm[hash_val];
+    int length = map_array->length;
     if(length == 0) {
-        map_array.maps = malloc(sizeof(keyval));
-        map_array.maps[0].key = key;
-        map_array.maps[0].values = dpush(dcreatea(), value);
-        map_array.length++;
-        hm[hash_val] = map_array;
+        map_array->maps = malloc(sizeof(keyval));
+        map_array->maps[0].key = key;
+        map_array->maps[0].values = dpush(dcreatea(), value);
+        map_array->length++;
+        //hm[hash_val] = map_array;
     } else {
         int index = -1;
         for(int i = 0; i < length; i++) {
-            keyval on = map_array.maps[i];
+            keyval on = map_array->maps[i];
             if(dequals(on.key, key)) {
                 index = i;
                 break;
@@ -40,18 +55,17 @@ hashmap *hset(hashmap *hm, dstring key, dstring value) {
         }
         int new_length = length + 1;
         if(index == -1) { // Element not in array
-            map_array.maps = realloc(map_array.maps, sizeof(keyval) * new_length);
+            map_array->maps = realloc(map_array->maps, sizeof(keyval) * new_length);
             dstringa values = dcreatea();
             values = dpush(values, value);
             keyval new_keyval = {key, values};
-            map_array.maps[length] = new_keyval;
-            map_array.length++;
-            hm[hash_val] = map_array;
+            map_array->maps[length] = new_keyval;
+            map_array->length++;
+            //hm[hash_val] = map_array;
         } else { // Element in array
-            dstringa values = map_array.maps[index].values;
+            dstringa values = map_array->maps[index].values;
             if(dindexofa(values, value) == -1) {
-                map_array.maps[index].values = dpush(values, value);
-                hm[hash_val] = map_array;
+                map_array->maps[index].values = dpush(values, value);
             }
         }
     }
@@ -59,15 +73,16 @@ hashmap *hset(hashmap *hm, dstring key, dstring value) {
     return hm;
 }
 
+
 dstringa hget(hashmap *hm, dstring key) {
-    int hash_val = hash(key.text);
+    int hash_val = hash(dtext(key));
     hashmap map_array = hm[hash_val];
     int length = map_array.length;
     if(length == 0) {
         dstringa empty = dcreatea();
         return empty;
     }
-    
+
     dstringa values = dcreatea();
     for(int i = 0; i < length; i++) {
         keyval on = map_array.maps[i];

--- a/fist/hashmap.h
+++ b/fist/hashmap.h
@@ -16,6 +16,7 @@ typedef struct hashmap {
 } hashmap;
 
 hashmap *hcreate();
+void hfree(hashmap *hm);
 hashmap *hset(hashmap *hm, dstring key, dstring value);
 dstringa hget(hashmap *hm, dstring key);
 

--- a/fist/indexer.c
+++ b/fist/indexer.c
@@ -8,23 +8,26 @@
 dstringa indexer(dstring text, int max_phrase_length) {
     dstringa words = dsplit(text, ' ');
     dstringa index = dcreatea();
-    
+
     int max_length = min(max_phrase_length, words.length);
-    
+
     for(int text_size = 0; text_size < words.length; text_size += max_phrase_length)  {
         for(int ahead = 0; ahead < max_length; ahead++) {
             for(int i = text_size; i < max_length + text_size; i++) {
                 int check_len = max_length + text_size;
                 if(check_len > words.length)
                     check_len = words.length;
-                if(i + ahead < check_len) { 
+                if(i + ahead < check_len) {
                     dstringa range = drange(words, i, i + ahead);
                     dstring joined = djoin(range, ' ');
                     index = dpush(index, joined);
+                    dfreea(range);
+                    dfree(joined);
                 }
             }
         }
     }
+    dfreea(words);
 
     return index;
 }

--- a/fist/serializer.c
+++ b/fist/serializer.c
@@ -8,8 +8,8 @@ void sdump(hashmap *hmap) {
     // Write size of hashmap to file. (# keys)
 
     FILE *dump = fopen("fist.db", "wb");
-    
-    int num_indices = 0; 
+
+    int num_indices = 0;
 
     for(int i = 0; i < HMAP_SIZE; i++) {
         // Get number of indices have values
@@ -17,7 +17,7 @@ void sdump(hashmap *hmap) {
         if(on.length > 0)
             num_indices++;
     }
-    
+
     fwrite(&num_indices, sizeof(num_indices), 1, dump);
     // Iterate through hashmap and write key and array of values to file
 
@@ -29,8 +29,8 @@ void sdump(hashmap *hmap) {
                 int length = object.key.length;
                 // Writes key length and key name to db file
                 fwrite(&length, sizeof(length), 1, dump);
-                fwrite(object.key.text, object.key.length, 1, dump);
-                
+                fwrite(dtext(object.key), object.key.length, 1, dump);
+
                 int num_values = object.values.length;
                 // Writes number of values associated with key to db file
                 fwrite(&num_values, sizeof(num_values), 1, dump);
@@ -39,7 +39,7 @@ void sdump(hashmap *hmap) {
                     dstring value_on = object.values.values[value];
                     int val_length = value_on.length;
                     fwrite(&val_length, sizeof(val_length), 1, dump);
-                    fwrite(value_on.text, value_on.length, 1, dump);
+                    fwrite(dtext(value_on), value_on.length, 1, dump);
                 }
             }
         }
@@ -58,7 +58,7 @@ hashmap *sload() {
             fread(&key_size, sizeof(key_size), 1, db);
             char key[key_size + 1];
             key[key_size] = 0;
-            fread(key, key_size, 1, db); 
+            fread(key, key_size, 1, db);
             int num_vals;
             fread(&num_vals, sizeof(num_vals), 1, db);
             //printf("%d %d %s %d\n", num_keys, key_size, key, num_vals);

--- a/fist/server.c
+++ b/fist/server.c
@@ -25,14 +25,14 @@
 #define INVALID_COMMAND "Invalid Command\n"
 #define BYE "Bye\n"
 
-hashmap * handle_connection(int new_socket, hashmap *hm) {  
+hashmap * handle_connection(int new_socket, hashmap *hm) {
     while(1) {
         dstring req = dempty();
         while(dindexof(req, '\n') == -1 || dindexof(req, '\r') == -1) {
             char buffer[1025]; // Need to preserve the last character being a null character
             memset(buffer, 0, 1025);
             int reqsize = recv(new_socket, buffer, 1024, 0); // Only fill 1024 of the 1025 bytes
-            if(reqsize == 0) 
+            if(reqsize == 0)
                 break;
             req = dappend(req, buffer);
         }
@@ -41,19 +41,19 @@ hashmap * handle_connection(int new_socket, hashmap *hm) {
 
         dstring trimmed = dtrim(req);
         dstringa commands = dsplit(trimmed, ' ');
-        printf("%d '%s'\n", req.length, trimmed.text);
+        printf("%d '%s'\n", req.length, dtext(trimmed));
         if(dequals(trimmed, dcreate(EXIT))) {
             send(new_socket, BYE, strlen(BYE), 0);
             break;
         }
-        if(dequals(commands.values[0], dcreate(INDEX))) { 
+        if(dequals(commands.values[0], dcreate(INDEX))) {
             printf("INDEX\n");
             if(commands.length < 3) {
-                send(new_socket, TOO_FEW_ARGUMENTS, strlen(TOO_FEW_ARGUMENTS), 0); 
+                send(new_socket, TOO_FEW_ARGUMENTS, strlen(TOO_FEW_ARGUMENTS), 0);
             } else {
                 dstring document = commands.values[1];
                 dstring text = djoin(drange(commands, 2, commands.length), ' ');
-                printf("TEXT: '%s'\n", text.text);
+                printf("TEXT: '%s'\n", dtext(text));
                 dstringa index = indexer(text, 10);
                 printf("INDEX SIZE: %d\n", index.length);
                 for(int i = 0; i < index.length; i++) {
@@ -68,7 +68,7 @@ hashmap * handle_connection(int new_socket, hashmap *hm) {
                 send(new_socket, TOO_FEW_ARGUMENTS, strlen(TOO_FEW_ARGUMENTS), 0);
             } else {
                 dstring text = djoin(drange(commands, 1, commands.length), ' ');
-                printf("SEARCH STRING: '%s'\n", text.text);
+                printf("SEARCH STRING: '%s'\n", dtext(text));
                 dstringa value = hget(hm, text);
                 printf("SEARCH RESULTS SIZE: %d\n", value.length);
                 if(!value.length) {
@@ -85,11 +85,11 @@ hashmap * handle_connection(int new_socket, hashmap *hm) {
                     }
                     output = dappendc(output, ']');
                     output = dappendc(output, '\n');
-                    send(new_socket, output.text, output.length, 0);
+                    send(new_socket, dtext(output), output.length, 0);
                 }
             }
         } else {
-            send(new_socket, INVALID_COMMAND, strlen(INVALID_COMMAND), 0); 
+            send(new_socket, INVALID_COMMAND, strlen(INVALID_COMMAND), 0);
         }
     }
     close(new_socket);
@@ -111,7 +111,7 @@ void start_server(char *host, int port) {
        perror("Problem setting sockopts");
        exit(EXIT_FAILURE);
     }
-    
+
     address.sin_family = AF_INET;
     address.sin_addr.s_addr = INADDR_ANY;
     address.sin_port = htons(port);
@@ -126,7 +126,7 @@ void start_server(char *host, int port) {
         exit(EXIT_FAILURE);
     }
 
-    printf("Fist started at localhost:%d\n", port); 
+    printf("Fist started at localhost:%d\n", port);
 
     hashmap *hm = sload(); // Loads database file if it exists, otherwise returns an empty hashmap
 

--- a/fist/tests.c
+++ b/fist/tests.c
@@ -12,37 +12,37 @@ int tests_run = 0;
 static char *test_empty_dstring() {
     dstring empty = dempty();
     mu_assert("dempty: Length 0", empty.length == 0);
-    mu_assert("dempty: Is empty", strlen(empty.text) == 0);
+    mu_assert("dempty: Is empty", strlen(dtext(empty)) == 0);
     return 0;
 }
 
 static char *test_create_dstring() {
     dstring string = dcreate("Hello World!");
     mu_assert("dcreate: Length Correct", string.length == strlen("Hello World!"));
-    mu_assert("dcreate: Equals 'Hello World!'", !strcmp(string.text, "Hello World!"));
+    mu_assert("dcreate: Equals 'Hello World!'", !strcmp(dtext(string), "Hello World!"));
     return 0;
 }
 
 static char *test_append_dstring() {
     dstring string = dcreate("Hello");
     mu_assert("dappend: Length Correst", string.length == strlen("Hello"));
-    mu_assert("dappend: Equals 'Hello'", !strcmp(string.text, "Hello"));
+    mu_assert("dappend: Equals 'Hello'", !strcmp(dtext(string), "Hello"));
     string = dappend(string, " World!");
-    mu_assert("dappend: Append Properly", !strcmp(string.text, "Hello World!"));
+    mu_assert("dappend: Append Properly", !strcmp(dtext(string), "Hello World!"));
     mu_assert("dappend: Length Updated", string.length == strlen("Hello World!"));
-    
+
     dstring empty = dempty();
     empty = dappend(empty, "Empty What?");
     mu_assert("dappend: Empty Append Length", empty.length == strlen("Empty What?"));
-    mu_assert("dappend: Empty Append Text", !strcmp("Empty What?", empty.text));
-   
+    mu_assert("dappend: Empty Append Text", !strcmp("Empty What?", dtext(empty)));
+
     return 0;
 }
 
 static char *test_reverse_dstring() {
     dstring string = dcreate("Reverse");
     dstring reversed = dreverse(string);
-    mu_assert("dreverse: Reversed", !strcmp(reversed.text, "esreveR"));
+    mu_assert("dreverse: Reversed", !strcmp(dtext(reversed), "esreveR"));
     mu_assert("dreverse: Reversed Length", reversed.length == string.length);
     return 0;
 }
@@ -57,13 +57,13 @@ static char *test_free_dstring() {
 static char *test_dappendc_dstring() {
     dstring string = dcreate("Hello");
     string = dappendc(string, '!');
-    mu_assert("dappendc: Char added", !strcmp(string.text, "Hello!"));
+    mu_assert("dappendc: Char added", !strcmp(dtext(string), "Hello!"));
     mu_assert("dappendc: Length correct", string.length == 6);
     char *other_chars = " How are you?";
     for(int i = 0; i < strlen(other_chars); i++) {
         string = dappendc(string, other_chars[i]);
     }
-    mu_assert("dappendc: Other chars added", !strcmp(string.text, "Hello! How are you?"));
+    mu_assert("dappendc: Other chars added", !strcmp(dtext(string), "Hello! How are you?"));
     mu_assert("dappendc: Length other chars", string.length == 19);
     return 0;
 }
@@ -100,12 +100,16 @@ static char *test_push_array_dstring() {
     dstringa array = dcreatea();
     array = dpush(array, test_val);
     mu_assert("dpush: Pushing first value length", array.length == 1);
-    mu_assert("dpush: Pushing first value check val", !strcmp(array.values[0].text, test_val.text));
+    mu_assert("dpush: Pushing first value check val", !strcmp(dtext(array.values[0]), dtext(test_val)));
     array = dpush(array, test_val_2);
     mu_assert("dpush: Pushing second value length", array.length == 2);
-    mu_assert("dpush: Pushing second value check val", !strcmp(array.values[1].text, test_val_2.text));
+    mu_assert("dpush: Pushing second value check val", !strcmp(dtext(array.values[1]), dtext(test_val_2)));
 
-    mu_assert("dpush: Check first and second val", !strcmp(array.values[0].text, test_val.text) && !strcmp(array.values[1].text, test_val_2.text));
+    mu_assert("dpush: Check first and second val", !strcmp(dtext(array.values[0]), dtext(test_val)) && !strcmp(dtext(array.values[1]), dtext(test_val_2)));
+
+    dfreea(array);
+    dfree(test_val);
+    dfree(test_val_2);
     return 0;
 }
 
@@ -128,6 +132,10 @@ static char *test_indexof_array_dstring() {
     array = dpush(array, test_val_2);
     int index = dindexofa(array, test_val_2);
     mu_assert("dindexof: Index correct", index == 1);
+
+    dfree(test_val_1);
+    dfree(test_val_2);
+    dfreea(array);
     return 0;
 }
 
@@ -137,9 +145,13 @@ static char *test_pop_array_dstring() {
     dstringa array = dcreatea();
     array = dpush(array, test_val_1);
     array = dpush(array, test_val_2);
-    mu_assert("dpop: Last item correct", !strcmp(array.values[1].text, test_val_2.text));
+    mu_assert("dpop: Last item correct", !strcmp(dtext(array.values[1]), dtext(test_val_2)));
     array = dpop(array);
     mu_assert("dpop: Correct size", array.length == 1);
+
+    dfree(test_val_1);
+    dfree(test_val_2);
+    dfreea(array);
     return 0;
 }
 
@@ -150,10 +162,14 @@ static char *test_remove_array_dstring() {
     array = dpush(array, test_val_1);
     array = dpush(array, test_val_2);
     mu_assert("dremove: Item exists", dindexofa(array, test_val_1) == 0);
-    mu_assert("dremove: Length correct", array.length == 2); 
+    mu_assert("dremove: Length correct", array.length == 2);
     array = dremove(array, test_val_1);
     mu_assert("dremove: Item removed", dindexofa(array, test_val_1) == -1);
     mu_assert("dremove: Length changed", array.length == 1);
+
+    dfree(test_val_1);
+    dfree(test_val_2);
+    dfreea(array);
     return 0;
 }
 
@@ -165,30 +181,36 @@ static char *test_set_array_dstring() {
     array = dpush(array, test_val_1);
     array = dpush(array, test_val_2);
     array = dset(array, 0, test_replace_val);
-    mu_assert("dset: First index reset", !strcmp(array.values[0].text, test_replace_val.text));
+    mu_assert("dset: First index reset", !strcmp(dtext(array.values[0]), dtext(test_replace_val)));
+
+    dfree(test_val_1);
+    dfree(test_val_2);
+    dfree(test_replace_val);
+    dfreea(array);
     return 0;
 }
 
 static char *test_substr_dstring() {
     dstring test_val = dcreate("Hello World!");
     dstring substr = dsubstr(test_val, 6, 10);
-    mu_assert("dsubstr: Equals World", !strcmp(substr.text, "World"));
+    mu_assert("dsubstr: Equals World", !strcmp(dtext(substr), "World"));
     return 0;
 }
 
 static char *test_trim_dstring() {
     dstring test_val = dcreate("\r\n Hello World! \r\n");
-    mu_assert("dtrim: Has Spaces", strcmp(test_val.text, "Hello World!"));
+    mu_assert("dtrim: Has Spaces", strcmp(dtext(test_val), "Hello World!"));
     test_val = dtrim(test_val);
-    mu_assert("dtrimg: Does not have spaces", !strcmp(test_val.text, "Hello World!"));
+    mu_assert("dtrimg: Does not have spaces", !strcmp(dtext(test_val), "Hello World!"));
+    dfree(test_val);
     return 0;
 }
 
 static char *test_replace_dstring() {
     dstring test_val = dcreate("Hello World!");
-    mu_assert("dreplace: Original Correct", !strcmp(test_val.text, "Hello World!"));
+    mu_assert("dreplace: Original Correct", !strcmp(dtext(test_val), "Hello World!"));
     test_val = dreplace(test_val, 'l', '1');
-    mu_assert("dreplace: Repalced Correct", !strcmp(test_val.text, "He11o Wor1d!"));
+    mu_assert("dreplace: Repalced Correct", !strcmp(dtext(test_val), "He11o Wor1d!"));
     return 0;
 }
 
@@ -196,11 +218,14 @@ static char *test_dsplit_dstring() {
     dstring test_val = dcreate("Hello my name is Frankie");
     dstringa split = dsplit(test_val, ' ');
     mu_assert("dsplit: Length", split.length == 5);
-    mu_assert("dsplit: 0", !strcmp(split.values[0].text, "Hello"));
-    mu_assert("dsplit: 1", !strcmp(split.values[1].text, "my")); 
-    mu_assert("dsplit: 2", !strcmp(split.values[2].text, "name"));
-    mu_assert("dsplit: 3", !strcmp(split.values[3].text, "is"));
-    mu_assert("dsplit: 4", !strcmp(split.values[4].text, "Frankie"));
+    mu_assert("dsplit: 0", !strcmp(dtext(split.values[0]), "Hello"));
+    mu_assert("dsplit: 1", !strcmp(dtext(split.values[1]), "my"));
+    mu_assert("dsplit: 2", !strcmp(dtext(split.values[2]), "name"));
+    mu_assert("dsplit: 3", !strcmp(dtext(split.values[3]), "is"));
+    mu_assert("dsplit: 4", !strcmp(dtext(split.values[4]), "Frankie"));
+
+    dfreea(split);
+    dfree(test_val);
 
     return 0;
 }
@@ -219,10 +244,13 @@ static char *test_getset_hm() {
     mu_assert("hset+hget: Test new value same key", dequals(output.values[1], value2));
     hm = hset(hm, key2, value);
     output = hget(hm, key2);
-    mu_assert("hset+hget: Test new value new key", dequals(output.values[0], value)); 
+    mu_assert("hset+hget: Test new value new key", dequals(output.values[0], value));
     hm = hset(hm, key2, value2);
     output = hget(hm, key2);
-    mu_assert("hset+hget: Test new value same key", dequals(output.values[1], value2)); 
+    mu_assert("hset+hget: Test new value same key", dequals(output.values[1], value2));
+    dfree(value);
+    dfree(value2);
+    hfree(hm);
     return 0;
 }
 
@@ -239,15 +267,19 @@ static char *test_indexer() {
     answers = dpush(answers, dcreate("This is very"));
     answers = dpush(answers, dcreate("is very cool"));
     answers = dpush(answers, dcreate("This is very cool"));
-    dstring t2 = dcreate("1 2 3 4 5 6 7 8 9 10 11 12 13");
-    indexer(t2, 10);
+    //dstring t2 = dcreate("1 2 3 4 5 6 7 8 9 10 11 12 13");
+    //indexer(t2, 10);
     dstringa index = indexer(test, 10);
-    
+
     for(int i = 0; i < answers.length; i++) {
         char *buffer = malloc(sizeof(char) * 1024);
-        sprintf(buffer, "indexer: Expecting '%s' got '%s'", answers.values[i].text, index.values[i].text);
+        sprintf(buffer, "indexer: Expecting '%s' got '%s' at %d", dtext(answers.values[i]), dtext(index.values[i]), i);
         mu_assert(buffer, dequals(answers.values[i], index.values[i]));
+        free(buffer);
     }
+    dfreea(answers);
+    //dfree(t2);
+    dfreea(index);
     return 0;
 }
 
@@ -268,16 +300,22 @@ static char *test_drange_dstring() {
 
     mu_assert("drange: Bad ranges 1", dequals(test2.values[0], dcreate("Hello")));
     mu_assert("drange: Bad ranges 2", dequals(test2.values[4], dcreate("cool")));
-    
+
     dstringa test3 = drange(test, 100, -1);
-    
+
     mu_assert("drange: Bad ranges 3", dequals(test3.values[0], dcreate("Hello")));
     mu_assert("drange: Bad ranges 4", dequals(test3.values[4], dcreate("cool")));
-    
+
     dstringa test4 = drange(test, 0, 0);
 
     mu_assert("drange: Same start and end", dequals(test4.values[0], dcreate("Hello")));
-    
+
+    dfreea(test);
+    dfreea(test1);
+    dfreea(test2);
+    dfreea(test3);
+    dfreea(test4);
+
     return 0;
 }
 
@@ -288,10 +326,14 @@ static char *test_djoin_dstring() {
     test = dpush(test, dcreate("is"));
     test = dpush(test, dcreate("really"));
     test = dpush(test, dcreate("cool"));
-    
+
     dstring answer = dcreate("Hello,this,is,really,cool");
     dstring joined = djoin(test, ',');
     mu_assert("djoin", dequals(answer, joined));
+
+    dfreea(test);
+    dfree(answer);
+    dfree(joined);
 
     return 0;
 }
@@ -301,6 +343,8 @@ static char *test_dappendd_dstring() {
     dstring append = dcreate(" World");
     text = dappendd(text, append);
     mu_assert("dappendd", dequals(text, dcreate("Hello World")));
+    dfree(text);
+    dfree(append);
     return 0;
 }
 
@@ -314,9 +358,9 @@ static char *test_serialize_hmap() {
     dstring value3 = dcreate("d3");
     hm = hset(hm, key, value);
     hm = hset(hm, key, value2);
-    hm = hset(hm, key2, value3); 
+    hm = hset(hm, key2, value3);
     sdump(hm);
-    hashmap *loaded = sload(); 
+    hashmap *loaded = sload();
     dstringa get_from_loaded = hget(loaded, key2);
     dstringa key1vals = hget(loaded, key);
     mu_assert("Serialized data size", get_from_loaded.length == 1);
@@ -324,6 +368,11 @@ static char *test_serialize_hmap() {
     mu_assert("key1 contains value", dequals(key1vals.values[0], value));
     mu_assert("key2 contains value2", dequals(key1vals.values[1], value2));
     rename("fist.db.real", "fist.db");
+    hfree(hm);
+    dfree(value);
+    dfree(value2);
+    dfree(value3);
+    hfree(loaded);
     return 0;
 }
 


### PR DESCRIPTION
This can significantly reduce the use of malloc/free which improves
performance.
Benchmarks (via valgrind):
Before change:
==22450==   total heap usage: 1,651 allocs, 966 frees, 48,079,988 bytes allocated
After change:
==22504==   total heap usage: 123 allocs, 122 frees, 48,040,224 bytes allocated

Note: I've only really tested this with the in-built test suite.