### PR TITLE
Use the given host argument when creating the server

### DIFF
--- a/fist/server.c
+++ b/fist/server.c
@@ -176,6 +176,11 @@ int start_server(char *host, int port) {
     // TODO: respect host parameter
     server_addr.sin_family = AF_INET;
     server_addr.sin_addr.s_addr = INADDR_ANY;
+    if(!inet_aton(host, &server_addr.sin_addr)) {
+        perror("inet_aton");
+        rc = -1;
+        goto exit;
+    }
     server_addr.sin_port = htons(port);
     if(bind(server_fd, (struct sockaddr *)&server_addr, sizeof(struct sockaddr_in)) == -1) {
         perror("bind");

--- a/fist/server.c
+++ b/fist/server.c
@@ -1,5 +1,6 @@
 #include "server.h"
 
+#include <arpa/inet.h>
 #include <errno.h>
 #include <netinet/in.h>
 #include <signal.h>
@@ -188,7 +189,7 @@ int start_server(char *host, int port) {
 	goto exit;
     }
 
-    printf("Fist started at localhost:%d\n", port);
+    printf("Fist started at %s:%d\n", inet_ntoa(server_addr.sin_addr), port);
 
     FD_SET(server_fd, &master_fds);
     fd_max = server_fd;


### PR DESCRIPTION
The `char *host` parameter received by `make_server` is hardcoded to 127.0.0.1, and the server logs localhost as the bound address once the server starts; yet the IP address bound to the socket is bound to 0.0.0.0 (which among other things makes the firewall ask about permissions before starting the server socket).

This merge request actually parses the given parameter by calling the appropiate network function so that it is decoded into a valid network address assigned to the socket. The result is also printed when the server starts.