### PR TITLE
Attempting to fix issue #29

### DIFF
--- a/fist/server.c
+++ b/fist/server.c
@@ -245,7 +245,7 @@ int start_server(char *host, int port) {
                         for(int j = 0; j < nbytes; j++) {
                             char on = buf[j];
                             this->last_command = dappendc(this->last_command, on);
-                            if (on == '\r') {
+                            if(on == '\r') {
                                 found_bs_r = 1;
                             } else if(on == '\n' && found_bs_r) {
                                 int should_close = process_command(hm, i, this->last_command);

--- a/fist/server.c
+++ b/fist/server.c
@@ -246,8 +246,28 @@ int start_server(char *host, int port) {
                            dindexof(this->last_command, '\r') == -1) {
                             continue;
                         }
+                        
+                        int found_bs_r = 0;
+                        dstring command = dempty();
+                        
+                        for(int j = 0; j < this->last_command.length; j++) {
+                            char on = dtext(this->last_command)[j];
+                            if(on == '\r') {
+                                found_bs_r = 1;
+                            } else {
+                                found_bs_r = 0;
+                            }
 
-                        int should_close = process_command(hm, i, this->last_command);
+                            if(found_bs_r && on == '\n') {
+                                process_command(hm, i, command);
+                                dfree(command);
+                                command = dempty();
+                            } else {
+                                command = dappendc(command, on);
+                            }
+                        }
+                        
+                        int should_close = process_command(hm, i, command);
                         dfree(this->last_command);
                         this->last_command = dempty();
                         if(should_close) {

--- a/fist/server.c
+++ b/fist/server.c
@@ -258,15 +258,15 @@ int start_server(char *host, int port) {
                                 found_bs_r = 0;
                             }
 
+                            command = dappendc(command, on);
+
                             if(found_bs_r && on == '\n') {
                                 process_command(hm, i, command);
                                 dfree(command);
                                 command = dempty();
-                            } else {
-                                command = dappendc(command, on);
                             }
                         }
-                        
+                        printf("LEFTOVER: %s\n", dtext(command)); 
                         int should_close = process_command(hm, i, command);
                         dfree(this->last_command);
                         this->last_command = dempty();

--- a/fist/server.c
+++ b/fist/server.c
@@ -254,6 +254,7 @@ int start_server(char *host, int port) {
                                     close(i);
                                     FD_CLR(i, &master_fds);
                                     dfree(connection_infos[i].last_command);
+                                    break;
                                 }
                             } else {
                                 found_bs_r = 0;

--- a/fist/server.c
+++ b/fist/server.c
@@ -102,6 +102,7 @@ static int process_command(hashmap *hm, int fd, dstring req) {
             }
         }
     } else {
+        printf("INVALID COMMAND: %s\n", dtext(req));
         send(fd, INVALID_COMMAND, strlen(INVALID_COMMAND), 0);
     }
 
@@ -240,40 +241,23 @@ int start_server(char *host, int port) {
                         dfree(connection_infos[i].last_command);
                     } else {
                         struct connection_info *this = &connection_infos[i];
-                        this->last_command = dappend(this->last_command, buf);
-
-                        if(dindexof(this->last_command, '\n') == -1 ||
-                           dindexof(this->last_command, '\r') == -1) {
-                            continue;
-                        }
-                        
                         int found_bs_r = 0;
-                        dstring command = dempty();
-                        
-                        for(int j = 0; j < this->last_command.length; j++) {
-                            char on = dtext(this->last_command)[j];
-                            if(on == '\r') {
+                        for(int j = 0; j < nbytes; j++) {
+                            char on = buf[j];
+                            this->last_command = dappendc(this->last_command, on);
+                            if (on == '\r') {
                                 found_bs_r = 1;
+                            } else if(on == '\n' && found_bs_r) {
+                                int should_close = process_command(hm, i, this->last_command);
+                                this->last_command = dempty();
+                                if(should_close) {
+                                    close(i);
+                                    FD_CLR(i, &master_fds);
+                                    dfree(connection_infos[i].last_command);
+                                }
                             } else {
                                 found_bs_r = 0;
                             }
-
-                            command = dappendc(command, on);
-
-                            if(found_bs_r && on == '\n') {
-                                process_command(hm, i, command);
-                                dfree(command);
-                                command = dempty();
-                            }
-                        }
-                        printf("LEFTOVER: %s\n", dtext(command)); 
-                        int should_close = process_command(hm, i, command);
-                        dfree(this->last_command);
-                        this->last_command = dempty();
-                        if(should_close) {
-                            close(i);
-                            FD_CLR(i, &master_fds);
-                            dfree(connection_infos[i].last_command);
                         }
                     }
                 }


### PR DESCRIPTION
@00-matt This PR is attempting to fix the issue discussed https://github.com/f-prime/fist/pull/23#issuecomment-506742004

What I am doing is reading the `this->last_command` variable before it is sent to `process_command` and splitting it at `\r\n` and sending everything before the new line characters. 

What I am worried about is that after the loop is done I am sending what is left of the `command` variable which could be only a fragment of the original block of text for example

`pig in a cage` when fragmented could become `ig in a cage` leading to false indices. I haven't been able to produce this issue when testing but I wanted to get a second set of eyes on the code before I merged it. 