### PR TITLE
Fixing database portability issue

### DIFF
--- a/fist/serializer.c
+++ b/fist/serializer.c
@@ -1,3 +1,4 @@
+#include "stdint.h"
 #include "serializer.h"
 #include "dstring.h"
 #include "hashmap.h"
@@ -9,10 +10,10 @@ void sdump(hashmap *hmap) {
 
     FILE *dump = fopen("fist.db", "wb");
 
-    int num_indices = 0;
-
+    uint32_t num_indices = 0;
+    
     for(int i = 0; i < HMAP_SIZE; i++) {
-        // Get number of indices have values
+        // Get number of indices that have values
         hashmap on = hmap[i];
         if(on.length > 0)
             num_indices++;
@@ -26,18 +27,18 @@ void sdump(hashmap *hmap) {
         if(on.length > 0) {
             for(int key = 0; key < on.length; key++) {
                 keyval object = on.maps[key];
-                int length = object.key.length;
+                uint32_t length = object.key.length;
                 // Writes key length and key name to db file
                 fwrite(&length, sizeof(length), 1, dump);
                 fwrite(dtext(object.key), object.key.length, 1, dump);
 
-                int num_values = object.values.length;
+                uint32_t num_values = object.values.length;
                 // Writes number of values associated with key to db file
                 fwrite(&num_values, sizeof(num_values), 1, dump);
                 for(int value = 0; value < object.values.length; value++) {
                     // Writes value to db file
                     dstring value_on = object.values.values[value];
-                    int val_length = value_on.length;
+                    uint32_t val_length = value_on.length;
                     fwrite(&val_length, sizeof(val_length), 1, dump);
                     fwrite(dtext(value_on), value_on.length, 1, dump);
                 }
@@ -51,24 +52,23 @@ hashmap *sload() {
     hashmap *hmap = hcreate();
     FILE *db;
     if((db = fopen("fist.db", "rb"))) {
-        int num_keys;
+        uint32_t num_keys;
         fread(&num_keys, sizeof(num_keys), 1, db);
         for(int i = 0; i < num_keys; i++) {
-            int key_size;
+            uint32_t key_size;
             fread(&key_size, sizeof(key_size), 1, db);
             char key[key_size + 1];
             key[key_size] = 0;
             fread(key, key_size, 1, db);
-            int num_vals;
+            uint32_t num_vals;
             fread(&num_vals, sizeof(num_vals), 1, db);
-            // printf("%d %d %s %d\n", num_keys, key_size, key, num_vals);
+            
             for(int j = 0; j < num_vals; j++) {
-                int val_size;
+                uint32_t val_size;
                 fread(&val_size, sizeof(val_size), 1, db);
                 char value[val_size + 1];
                 value[val_size] = 0;
                 fread(value, val_size, 1, db);
-                // printf("%d %s\n", val_size, value);
                 hmap = hset(hmap, dcreate(key), dcreate(value));
             }
         }


### PR DESCRIPTION
Using uint32_t instead of int when reading and writing from db file to ensure that the db file is portable across other platforms.