### PR TITLE
Add man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,8 +92,12 @@ distclean: clean
 
 install: $(BIN)
 	install -D $(BIN) $(DESTDIR)$(prefix)/bin/fist
+	install -D fist.1 $(DESTDIR)$(prefix)/man/man1/fist.1
+	install -D fist_config.5 $(DESTDIR)$(prefix)/man/man5/fist_config.5
 
 uninstall:
-	-$(RM) $(DESTDIR)$(prefix)/bin/fist
+	-$(RM) $(DESTDIR)$(prefix)/bin/fist \
+		$(DESTDIR)$(prefix)/man/man1/fist.1 \
+		$(DESTDIR)$(prefix)/man/man5/fist_config.5
 
 -include $(BIN_DEPS)

--- a/fist.1
+++ b/fist.1
@@ -1,0 +1,22 @@
+.TH FIST 1
+.SH NAME
+fist \- a full\-text search engine
+.SH SYNOPSIS
+.B fist
+[\fB\-c\fR \fICONFIG\fR]
+[\fB\-t\fR]
+[\fB\-V\fR]
+.SH DESCRIPTION
+.B fist
+is a fast, lightweight, full\-text search and index server.
+Fist stores all information in memory making lookups very fast while also persisting the index to disk. The index can be accessed over a TCP connection and all data returned is valid JSON.
+.SH OPTIONS
+.TP
+.BR \-c\ \fICONFIG\fR
+Load configuration from the file at \fICONFIG\fR instead of from the system config file.
+.TP
+.BR \-t
+Run automated tests and exit.
+.TP
+.BR \-V
+Print version and exit.

--- a/fist.1
+++ b/fist.1
@@ -20,3 +20,5 @@ Run automated tests and exit.
 .TP
 .BR \-V
 Print version and exit.
+.SH SEE ALSO
+fist_config(5)

--- a/fist_config
+++ b/fist_config
@@ -1,4 +1,5 @@
-DatabaseFile Host 0.0.0.0
+DatabaseFile fist.db
+Host 0.0.0.0
 Port 1234
 MaxPhraseLength 11
 SavePeriod 500

--- a/fist_config.5
+++ b/fist_config.5
@@ -1,0 +1,51 @@
+.TH FIST_CONFIG 5
+.SH NAME
+fist_config \- fist configuration file
+.SH DESCRIPTION
+The file contains one key-value per line.
+Note that all values are case sensitive.
+The possible keywords are as follows:
+.TP
+DatabaseFile
+Path to the database file.
+Can be an absolute or relative path.
+Defaults to
+.I ./fist.db
+if unspecified.
+.TP
+Host
+The address to bind on. Defaults to
+.I 127.0.0.1
+if unspecified.
+.TP
+Port
+The port to bind on. Defaults to
+.I 5575
+if unspecified.
+.TP
+MaxPhraseLength
+The maximum length of an indexed phrase. Defaults to
+.I 10
+if unspecified.
+.TP
+SavePeriod
+The number of seconds between each save, if the database is dirty.
+Defaults to
+.I 120
+if unspecified.
+.TP
+SoBacklog
+The number of sockets to leave queued up while the server is busy, e.g. busy indexing a very long document.
+Defaults to
+.I 10
+if unspecified.
+.SH EXAMPLE
+.EX
+Host 0.0.0.0
+Port 5575
+DatabaseFile /var/lib/fist/fist.db
+MaxPhraseLength 12
+SavePeriod 600
+.EE
+.SH SEE ALSO
+fist(1)


### PR DESCRIPTION
##### Preview of `fist(1)`

```
FIST(1)                     General Commands Manual                    FIST(1)

NAME
       fist - a full-text search engine

SYNOPSIS
       fist [-c CONFIG] [-t] [-V]

DESCRIPTION
       fist  is  a fast, lightweight, full-text search and index server.  Fist
       stores all information in memory making lookups very  fast  while  also
       persisting the index to disk. The index can be accessed over a TCP con‐
       nection and all data returned is valid JSON.

OPTIONS
       -c CONFIG
              Load configuration from the file at CONFIG instead of  from  the
              system config file.

       -t     Run automated tests and exit.

       -V     Print version and exit.

SEE ALSO
       fist_config(5)

                                                                       FIST(1)
```

##### Preview of `fist_config(5)`

```
FIST_CONFIG(5)                File Formats Manual               FIST_CONFIG(5)

NAME
       fist_config - fist configuration file

DESCRIPTION
       The  file  contains  one  key-value per line.  Note that all values are
       case sensitive.  The possible keywords are as follows:

       DatabaseFile
              Path to the database file.  Can be an absolute or relative path.
              Defaults to ./fist.db if unspecified.

       Host   The address to bind on. Defaults to 127.0.0.1 if unspecified.

       Port   The port to bind on. Defaults to 5575 if unspecified.

       MaxPhraseLength
              The  maximum  length of an indexed phrase. Defaults to 10 if un‐
              specified.

       SavePeriod
              The number of seconds between each  save,  if  the  database  is
              dirty.  Defaults to 120 if unspecified.

       SoBacklog
              The  number  of  sockets  to leave queued up while the server is
              busy, e.g. busy indexing a very long document.  Defaults  to  10
              if unspecified.

EXAMPLE
       Host 0.0.0.0
       Port 5575
       DatabaseFile /var/lib/fist/fist.db
       MaxPhraseLength 12
       SavePeriod 600

SEE ALSO
       fist(1)

                                                                FIST_CONFIG(5)
```